### PR TITLE
Introduce ability for subcommands at any depth level

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,29 @@
+
+# Master
+
+### Breaking
+- None
+
+### Other
+- None
+
+
+# 0.1.0
+
+### Breaking
+- Introduce capability of writting subcommands to any depth level
+- Command instances must be classes in order to allow subcommands
+- Command instances must define an empty array of subcommands
+- Command instances must retain a reference to their argument sub-parser
+
+
+# 0.0.2
+
+### Other
+- Update Logger dependency
+
+
+# 0.0.1
+
+### Other
+- Initial release

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "Logger",
         "repositoryURL": "https://github.com/eneko/Logger.git",
         "state": {
-          "branch": "master",
+          "branch": null,
           "revision": "146a17c68a442859ec409b2ae1a23d1913d48c5d",
-          "version": null
+          "version": "0.0.2"
         }
       },
       {

--- a/Sources/CommandRegistry/Command.swift
+++ b/Sources/CommandRegistry/Command.swift
@@ -2,10 +2,18 @@ import Foundation
 import Utility
 import Basic
 
-public protocol Command {
+public protocol Command: class {
     var command: String { get }
     var overview: String { get }
+    var subparser: ArgumentParser { get }
+    var subcommands: [Command] { get set }
 
     init(parser: ArgumentParser)
     func run(with arguments: ArgumentParser.Result) throws
+}
+
+extension Command {
+    public func printUsage() {
+        subparser.printUsage(on: stdoutStream)
+    }
 }


### PR DESCRIPTION
With this update, commands can now have subcommands.
```
$ executable <command> <subcommand> <sub-subcommand> ...
```

Other updates:
- Update resolved dependencies
- Add `CHANGELOG`
